### PR TITLE
Compatibility with Mantis 2.21.0

### DIFF
--- a/files/BetterStatusColors.js
+++ b/files/BetterStatusColors.js
@@ -3,18 +3,19 @@ jQuery( document ).ready( function()
 	jQuery( '#buglist tbody tr' ).each( function( i, tr )
 	{
 		var status = jQuery( tr ).find( 'td.column-status i' );
-		
+
 		if( status.length ) {
 			var classes = status.attr( 'class' ).split( /\s+/ );
-		
+
 			classes = jQuery.grep( classes, function( c ) { return /^status-/.test( c ); } );
-		
+
 			if( classes.length ) {
-				status.parentsUntil( 'tr' ).addClass( classes[ 0 ] );			
+				var colorClass = classes[0].replace('-fg', '-bg');
+				status.parentsUntil( 'tr' ).addClass( colorClass );
 				status.hide();
 			}
 
-			jQuery( 'td.column-status > div' ).css( 'color', '#393939' ); 
+			jQuery( 'td.column-status > div' ).css( 'color', '#393939' );
 		}
 	} );
 } );


### PR DESCRIPTION
When upgrading to Mantis 2.21.0, the plugin did not work because the class names for colours have changed.

Where there was one status-##-color class covering text and background colours, there is now a status-##-fg class and a status-##-bg class.